### PR TITLE
Avoid using the bevy import directly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,16 +11,27 @@ license = "MIT"
 name = "bevy_points"
 readme = "README.md"
 repository = "https://github.com/mattatz/bevy_points"
-version = "0.8.0"
+version = "0.8.1"
 
-[dependencies.bevy]
-default-features = false
-features = ["bevy_render", "bevy_pbr", "bevy_asset", "tonemapping_luts"]
-version = "0.16.0"
+[dependencies]
+bevy_app = { version = "0.16.0", default-features = false }
+bevy_asset = { version = "0.16.0", default-features = false }
+bevy_color = { version = "0.16.0", default-features = false }
+bevy_core_pipeline = { version = "0.16.0", default-features = false, features = ["tonemapping_luts"] }
+bevy_ecs = { version = "0.16.0", default-features = false }
+bevy_math = { version = "0.16.0", default-features = false }
+bevy_pbr = { version = "0.16.0", default-features = false }
+bevy_reflect = { version = "0.16.0", default-features = false }
+bevy_render = { version = "0.16.0", default-features = false }
 
-[features]
-"examples" = ["bevy/bevy_core_pipeline", "bevy/bevy_winit", "bevy/x11", "bevy/bevy_window"]
+[dev-dependencies]
+bevy = { version = "0.16.0", default-features = false, features = [
+    "bevy_core_pipeline",
+    "bevy_pbr",
+    "bevy_winit",
+    "x11",
+    "bevy_window",
+] }
 
 [[example]]
 name = "scene"
-required-features = ["examples"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
-use bevy::{
-    asset::weak_handle,
-    prelude::{Handle, Shader},
-};
+use bevy_asset::{weak_handle, Handle};
+use bevy_render::render_resource::Shader;
 
 pub mod material;
 pub mod mesh;

--- a/src/material.rs
+++ b/src/material.rs
@@ -1,10 +1,11 @@
-use bevy::{
-    asset::Asset,
-    color::LinearRgba,
-    pbr::{MAX_CASCADES_PER_LIGHT, MAX_DIRECTIONAL_LIGHTS},
-    prelude::{AlphaMode, Material, Mesh},
-    reflect::TypePath,
-    render::render_resource::{AsBindGroup, ShaderDefVal, ShaderType},
+use bevy_asset::Asset;
+use bevy_color::LinearRgba;
+use bevy_pbr::{Material, MAX_CASCADES_PER_LIGHT, MAX_DIRECTIONAL_LIGHTS};
+use bevy_reflect::TypePath;
+use bevy_render::{
+    alpha::AlphaMode,
+    mesh::Mesh,
+    render_resource::{AsBindGroup, ShaderDefVal, ShaderType},
 };
 
 use crate::SHADER_HANDLE;
@@ -69,15 +70,15 @@ impl From<&PointsMaterial> for PointsMaterialKey {
 }
 
 impl Material for PointsMaterial {
-    fn vertex_shader() -> bevy::render::render_resource::ShaderRef {
-        bevy::render::render_resource::ShaderRef::Handle(SHADER_HANDLE.clone())
+    fn vertex_shader() -> bevy_render::render_resource::ShaderRef {
+        bevy_render::render_resource::ShaderRef::Handle(SHADER_HANDLE.clone())
     }
 
-    fn fragment_shader() -> bevy::render::render_resource::ShaderRef {
-        bevy::render::render_resource::ShaderRef::Handle(SHADER_HANDLE.clone())
+    fn fragment_shader() -> bevy_render::render_resource::ShaderRef {
+        bevy_render::render_resource::ShaderRef::Handle(SHADER_HANDLE.clone())
     }
 
-    fn alpha_mode(&self) -> bevy::prelude::AlphaMode {
+    fn alpha_mode(&self) -> AlphaMode {
         self.alpha_mode
     }
 
@@ -86,11 +87,11 @@ impl Material for PointsMaterial {
     }
 
     fn specialize(
-        _pipeline: &bevy::pbr::MaterialPipeline<Self>,
-        descriptor: &mut bevy::render::render_resource::RenderPipelineDescriptor,
-        layout: &bevy::render::mesh::MeshVertexBufferLayoutRef,
-        key: bevy::pbr::MaterialPipelineKey<Self>,
-    ) -> Result<(), bevy::render::render_resource::SpecializedMeshPipelineError> {
+        _pipeline: &bevy_pbr::MaterialPipeline<Self>,
+        descriptor: &mut bevy_render::render_resource::RenderPipelineDescriptor,
+        layout: &bevy_render::mesh::MeshVertexBufferLayoutRef,
+        key: bevy_pbr::MaterialPipelineKey<Self>,
+    ) -> Result<(), bevy_render::render_resource::SpecializedMeshPipelineError> {
         descriptor.primitive.cull_mode = None;
 
         let mut shader_defs = vec![];

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -1,11 +1,9 @@
-use bevy::{
-    color::{ColorToComponents, Srgba},
-    prelude::{Color, Mesh, Vec3},
-    render::{
-        mesh::{Indices, VertexAttributeValues},
-        render_asset::RenderAssetUsages,
-        render_resource::PrimitiveTopology,
-    },
+use bevy_color::{Color, ColorToComponents, Srgba};
+use bevy_math::Vec3;
+use bevy_render::{
+    mesh::{Indices, Mesh, VertexAttributeValues},
+    render_asset::RenderAssetUsages,
+    render_resource::PrimitiveTopology,
 };
 
 #[derive(Default)]

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,14 +1,14 @@
-use bevy::{
-    asset::load_internal_asset,
-    prelude::{MaterialPlugin, Plugin, Shader},
-};
+use bevy_app::Plugin;
+use bevy_asset::load_internal_asset;
+use bevy_pbr::MaterialPlugin;
+use bevy_render::render_resource::Shader;
 
 use crate::{prelude::PointsMaterial, SHADER_HANDLE};
 
 pub struct PointsPlugin;
 
 impl Plugin for PointsPlugin {
-    fn build(&self, app: &mut bevy::prelude::App) {
+    fn build(&self, app: &mut bevy_app::App) {
         load_internal_asset!(
             app,
             SHADER_HANDLE,


### PR DESCRIPTION
This change makes it so projects using this crate are not necessarily forced to have bevy in their dependency tree. Compile time is also slightly improved and the examples features could be omitted by using dev-dependencies.

<details>
  <summary>Build timings</summary>
  
| Before | After |
| ------ | ----- |
|![image](https://github.com/user-attachments/assets/64fc1c45-45e7-4d0c-a52e-759432d0b5de) |![image](https://github.com/user-attachments/assets/fa89e8ec-bd8e-48ca-9d13-2b01dd78296d) |

</details>