### PR TITLE
change shader layout to match bevy prepass_io shader

### DIFF
--- a/src/material.rs
+++ b/src/material.rs
@@ -111,7 +111,7 @@ impl Material for PointsMaterial {
 
         if key.bind_group_data.use_vertex_color && layout.0.contains(Mesh::ATTRIBUTE_COLOR) {
             shader_defs.push(ShaderDefVal::from("VERTEX_COLORS"));
-            vertex_attributes.push(Mesh::ATTRIBUTE_COLOR.at_shader_location(2));
+            vertex_attributes.push(Mesh::ATTRIBUTE_COLOR.at_shader_location(7));
         }
         if key.bind_group_data.perspective {
             shader_defs.push(ShaderDefVal::from("POINT_SIZE_PERSPECTIVE"));

--- a/src/shaders/points.wgsl
+++ b/src/shaders/points.wgsl
@@ -16,7 +16,7 @@ struct Vertex {
     @location(0) position: vec3<f32>,
     @location(1) uv: vec2<f32>,
 #ifdef VERTEX_COLORS
-    @location(2) color: vec4<f32>,
+    @location(7) color: vec4<f32>, // use location 7 to match the 'bevy_pbr/src/prepass/prepass_io.wgsl' shader
 #endif
 };
 
@@ -24,7 +24,7 @@ struct VertexOutput {
     @builtin(position) clip_position: vec4<f32>,
     @location(0) uv: vec2<f32>,
 #ifdef VERTEX_COLORS
-    @location(1) color: vec4<f32>,
+    @location(8) color: vec4<f32>, // use location 8 to match the 'bevy_pbr/src/prepass/prepass_io.wgsl' shader
 #endif
 };
 
@@ -56,7 +56,7 @@ fn vertex(vertex: Vertex) -> VertexOutput {
 struct FragmentInput {
     @location(0) uv: vec2<f32>,
 #ifdef VERTEX_COLORS
-    @location(1) color: vec4<f32>,
+    @location(8) color: vec4<f32>, // use location 8 to match the 'bevy_pbr/src/prepass/prepass_io.wgsl' shader
 #endif
 };
 


### PR DESCRIPTION
This PR changes the layout of the Vertex(Output) and FragmentInput struct to match the layout defined in the ``bevy_pbr/src/prepass/prepass_io.wgsl`` shader that is used for the depth/geometry prepass, which is necessary for bevy's occlusion culling.